### PR TITLE
Allow to specify multiple components

### DIFF
--- a/cabal-add.cabal
+++ b/cabal-add.cabal
@@ -30,6 +30,7 @@ library
     build-depends:
         base <5,
         bytestring <0.13,
+        foldable1-classes-compat >= 0.1,
         Cabal-syntax >=3.8 && <3.11,
         containers <0.8
 


### PR DESCRIPTION
This doesn't work properly yet.

* `roughAlgorithm` works, it's the easiest due to `splitAtPositionLine`
* `niceAlgorithm` doesn't work, it seems my offset logic doesn't play well with `splitAtPosition`... I wasn't able to figure out why yet
* `fancyAlgorithm`: haven't tried yet

My idea was:

* don't re-parse the cabal file, instead parse and insert "as we go", because usually we only care about a specific line and everything coming after it... so we just need to compute the correct offsets for the next component and then execute the next iteration

An alternative I tried was: using the original cabal file bytestring for each component, then returning position + bytestring-to-insert and combine that in one pass. But here we also need to compute offsets, which is the main difficulty.