### PR TITLE
Add library support for adding modules to components

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,7 +17,7 @@ import Data.ByteString (ByteString)
 import Data.ByteString.Char8 qualified as B
 import Data.Either (partitionEithers)
 import Data.List qualified as L
-import Data.List.NonEmpty (NonEmpty (..), toList)
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe (catMaybes, isJust)
 import Distribution.CabalSpecVersion (CabalSpecVersion)
 import Distribution.Client.Add
@@ -165,7 +165,7 @@ mkInputs isCmpRequired cabalFile origContents args = do
       if isCmpRequired
         then Left "Target component is required"
         else (,) <$> mkCmp Nothing <*> mkDeps args
-  pure $ Input cabalFile packDescr (Config origContents fields cmp deps BuildDepends)
+  pure $ Input cabalFile packDescr (Config origContents fields cmp BuildDepends deps)
 
 disambiguateInputs
   :: Maybe FilePath

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,7 +17,7 @@ import Data.ByteString (ByteString)
 import Data.ByteString.Char8 qualified as B
 import Data.Either (partitionEithers)
 import Data.List qualified as L
-import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty (NonEmpty (..), toList)
 import Data.Maybe (catMaybes, isJust)
 import Distribution.CabalSpecVersion (CabalSpecVersion)
 import Distribution.Client.Add
@@ -165,7 +165,7 @@ mkInputs isCmpRequired cabalFile origContents args = do
       if isCmpRequired
         then Left "Target component is required"
         else (,) <$> mkCmp Nothing <*> mkDeps args
-  pure $ Input cabalFile packDescr (Config origContents fields cmp deps)
+  pure $ Input cabalFile packDescr (Config origContents fields cmp deps BuildDepends)
 
 disambiguateInputs
   :: Maybe FilePath

--- a/cabal-add.cabal
+++ b/cabal-add.cabal
@@ -86,3 +86,20 @@ test-suite cabal-add-tests
         string-qq,
         tasty,
         temporary
+
+test-suite cabal-add-unit-tests
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       tests/
+  main-is:              UnitTests.hs
+  build-depends:
+        base <5,
+        bytestring,
+        Cabal,
+        cabal-add,
+        Diff >=0.4,
+        directory,
+        process,
+        string-qq,
+        tasty,
+        temporary
+

--- a/cabal-add.cabal
+++ b/cabal-add.cabal
@@ -88,10 +88,12 @@ test-suite cabal-add-tests
         temporary
 
 test-suite cabal-add-unit-tests
-  type:                 exitcode-stdio-1.0
-  hs-source-dirs:       tests/
-  main-is:              UnitTests.hs
-  build-depends:
+    type:             exitcode-stdio-1.0
+    main-is:          UnitTests.hs
+    hs-source-dirs:   tests/
+    default-language: GHC2021
+    ghc-options:      -Wall
+    build-depends:
         base <5,
         bytestring,
         Cabal,
@@ -102,4 +104,3 @@ test-suite cabal-add-unit-tests
         string-qq,
         tasty,
         temporary
-

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -1,0 +1,250 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- |
+-- Copyright:   (c) 2023 Bodigrim
+-- License:     BSD-3-Clause
+module Main (main) where
+
+import Data.Algorithm.Diff (Diff, PolyDiff (..), getDiff)
+import Data.ByteString.Char8 qualified as B
+import Data.Char (isAlpha)
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe (mapMaybe)
+import Data.String.QQ (s)
+import Distribution.Client.Add (Config (..), TargetField (..), executeConfig, parseCabalFile)
+import Distribution.PackageDescription (ComponentName (..), LibraryName (..), TestSuite (TestSuite))
+import System.Directory (findExecutable)
+import System.Exit (ExitCode (..))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (cwd, env, proc, readCreateProcessWithExitCode)
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.Providers (IsTest (..), singleTest, testFailed, testPassed)
+
+data CabalAddTest = CabalAddTest
+  { catName :: String
+  , catConfig :: Config
+  , catOutput :: String
+  }
+
+instance IsTest CabalAddTest where
+  testOptions = pure []
+
+  run _opts CabalAddTest {..} _yieldProgress = do
+    let template = map (\c -> if isAlpha c then c else '_') catName
+    let outputM = executeConfig (const $ const True) catConfig
+    case outputM of
+      Nothing -> pure $ testFailed "config could not be applied"
+      Just output ->
+        pure $
+          if B.unpack output == catOutput
+            then testPassed ""
+            else testFailed $ prettyDiff $ getDiff (lines catOutput) (lines (B.unpack output))
+
+caseMultipleBuildDependencies1 :: TestTree
+caseMultipleBuildDependencies1 =
+  mkTest $
+    CabalAddTest
+      { catName = "add multiple dependencies 1"
+      , catConfig =
+          Config
+            { cnfComponent = Right $ CLibName LMainLibName
+            , cnfAdditions = NE.fromList ["foo < 1 && >0.7", "baz ^>= 2.0"]
+            , cnfTargetField = BuildDepends
+            , cnfFields =
+                let Right (fields, _) = parseCabalFile "" inContents
+                 in fields
+            , cnfOrigContents = inContents
+            }
+      , catOutput =
+          [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+library
+  build-depends:
+    foo < 1 && >0.7,
+    baz ^>= 2.0,
+    base >=4.15 && <5
+|]
+      }
+  where
+    inContents =
+      [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+library
+  build-depends:
+    base >=4.15 && <5
+|]
+
+caseMultipleExposedModules1 :: TestTree
+caseMultipleExposedModules1 =
+  mkTest $
+    CabalAddTest
+      { catName = "add multiple exposed modules 1"
+      , catConfig =
+          Config
+            { cnfComponent = Right $ CLibName LMainLibName
+            , cnfAdditions = NE.fromList ["Test.Mod1, Test.Mod2"]
+            , cnfTargetField = ExposedModules
+            , cnfFields =
+                let Right (fields, _) = parseCabalFile "" inContents
+                 in fields
+            , cnfOrigContents = inContents
+            }
+      , catOutput =
+          [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+library
+  build-depends:
+    base >=4.15 && <5
+  exposed-modules: Test.Mod1, Test.Mod2, Main, OtherModule.Mine
+|]
+      }
+  where
+    inContents =
+      [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+library
+  build-depends:
+    base >=4.15 && <5
+  exposed-modules: Main, OtherModule.Mine
+|]
+
+caseMultipleExposedModulesUsingSpaces :: TestTree
+caseMultipleExposedModulesUsingSpaces =
+  mkTest $
+    CabalAddTest
+      { catName = "add multiple exposed modules with spaces"
+      , catConfig =
+          Config
+            { cnfComponent = Right $ CLibName LMainLibName
+            , cnfAdditions = NE.fromList ["Test.Mod1, Test.Mod2"]
+            , cnfTargetField = ExposedModules
+            , cnfFields =
+                let Right (fields, _) = parseCabalFile "" inContents
+                 in fields
+            , cnfOrigContents = inContents
+            }
+      , catOutput =
+          [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+library
+  build-depends:
+    base >=4.15 && <5
+  exposed-modules: Test.Mod1 Test.Mod2 Main OtherModule.Mine
+|]
+      }
+  where
+    inContents =
+      [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+library
+  build-depends:
+    base >=4.15 && <5
+  exposed-modules: Main OtherModule.Mine
+|]
+
+caseMultipleOtherModules :: TestTree
+caseMultipleOtherModules =
+  mkTest $
+    CabalAddTest
+      { catName = "add multiple other modules"
+      , catConfig =
+          Config
+            { cnfComponent = Right $ CTestName "testss"
+            , cnfAdditions = NE.fromList ["Test.Mod1, Mod3"]
+            , cnfTargetField = OtherModules
+            , cnfFields =
+                let Right (fields, _) = parseCabalFile "" inContents
+                 in fields
+            , cnfOrigContents = inContents
+            }
+      , catOutput =
+          [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+library
+  build-depends:
+    base >=4.15 && <5
+  exposed-modules: Test.Mod1 Test.Mod2
+test-suite testss
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
+  other-modules:
+    Test.Mod1, Mod3,
+    Dir.Mod1,
+    Dir.Mod2
+|]
+      }
+  where
+    inContents =
+      [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+library
+  build-depends:
+    base >=4.15 && <5
+  exposed-modules: Test.Mod1 Test.Mod2
+test-suite testss
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
+  other-modules:
+    Dir.Mod1,
+    Dir.Mod2
+|]
+
+prettyDiff :: [Diff String] -> String
+prettyDiff =
+  unlines
+    . mapMaybe
+      ( \case
+          First xs -> Just $ '-' : xs
+          Second ys -> Just $ '+' : ys
+          Both xs _ -> Just $ ' ' : xs
+      )
+
+mkTest :: CabalAddTest -> TestTree
+mkTest cat = singleTest (catName cat) cat
+
+main :: IO ()
+main =
+  defaultMain $
+    testGroup
+      "All Unit Tests"
+      [ caseMultipleBuildDependencies1
+      , caseMultipleExposedModules1
+      , caseMultipleExposedModulesUsingSpaces
+      , caseMultipleOtherModules
+      ]

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -11,16 +11,13 @@ module Main (main) where
 
 import Data.Algorithm.Diff (Diff, PolyDiff (..), getDiff)
 import Data.ByteString.Char8 qualified as B
-import Data.Char (isAlpha)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (mapMaybe)
 import Data.String.QQ (s)
 import Distribution.Client.Add (Config (..), TargetField (..), executeConfig, parseCabalFile)
-import Distribution.PackageDescription (ComponentName (..), LibraryName (..), TestSuite (TestSuite))
-import System.Directory (findExecutable)
-import System.Exit (ExitCode (..))
-import System.IO.Temp (withSystemTempDirectory)
-import System.Process (cwd, env, proc, readCreateProcessWithExitCode)
+import Distribution.Fields.Field (Field)
+import Distribution.PackageDescription (ComponentName (..), LibraryName (..))
+import Distribution.Parsec.Position (Position)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.Providers (IsTest (..), singleTest, testFailed, testPassed)
 
@@ -34,7 +31,6 @@ instance IsTest CabalAddTest where
   testOptions = pure []
 
   run _opts CabalAddTest {..} _yieldProgress = do
-    let template = map (\c -> if isAlpha c then c else '_') catName
     let outputM = executeConfig (const $ const True) catConfig
     case outputM of
       Nothing -> pure $ testFailed "config could not be applied"
@@ -43,6 +39,11 @@ instance IsTest CabalAddTest where
           if B.unpack output == catOutput
             then testPassed ""
             else testFailed $ prettyDiff $ getDiff (lines catOutput) (lines (B.unpack output))
+
+parseCabalFileOrError :: B.ByteString -> [Field Position]
+parseCabalFileOrError inContents = case parseCabalFile "" inContents of
+  Right (fields, _) -> fields
+  Left err -> error $ "Failed to parse cabal file with error: " <> err
 
 caseMultipleBuildDependencies1 :: TestTree
 caseMultipleBuildDependencies1 =
@@ -54,9 +55,7 @@ caseMultipleBuildDependencies1 =
             { cnfComponent = Right $ CLibName LMainLibName
             , cnfAdditions = NE.fromList ["foo < 1 && >0.7", "baz ^>= 2.0"]
             , cnfTargetField = BuildDepends
-            , cnfFields =
-                let Right (fields, _) = parseCabalFile "" inContents
-                 in fields
+            , cnfFields = parseCabalFileOrError inContents
             , cnfOrigContents = inContents
             }
       , catOutput =
@@ -94,11 +93,9 @@ caseMultipleExposedModules1 =
       , catConfig =
           Config
             { cnfComponent = Right $ CLibName LMainLibName
-            , cnfAdditions = NE.fromList ["Test.Mod1, Test.Mod2"]
+            , cnfAdditions = NE.fromList ["Test.Mod1", "Test.Mod2"]
             , cnfTargetField = ExposedModules
-            , cnfFields =
-                let Right (fields, _) = parseCabalFile "" inContents
-                 in fields
+            , cnfFields = parseCabalFileOrError inContents
             , cnfOrigContents = inContents
             }
       , catOutput =
@@ -136,11 +133,9 @@ caseMultipleExposedModulesUsingSpaces =
       , catConfig =
           Config
             { cnfComponent = Right $ CLibName LMainLibName
-            , cnfAdditions = NE.fromList ["Test.Mod1, Test.Mod2"]
+            , cnfAdditions = NE.fromList ["Test.Mod1", "Test.Mod2"]
             , cnfTargetField = ExposedModules
-            , cnfFields =
-                let Right (fields, _) = parseCabalFile "" inContents
-                 in fields
+            , cnfFields = parseCabalFileOrError inContents
             , cnfOrigContents = inContents
             }
       , catOutput =
@@ -178,11 +173,9 @@ caseMultipleOtherModules =
       , catConfig =
           Config
             { cnfComponent = Right $ CTestName "testss"
-            , cnfAdditions = NE.fromList ["Test.Mod1, Mod3"]
+            , cnfAdditions = NE.fromList ["Test.Mod1", "Mod3"]
             , cnfTargetField = OtherModules
-            , cnfFields =
-                let Right (fields, _) = parseCabalFile "" inContents
-                 in fields
+            , cnfFields = parseCabalFileOrError inContents
             , cnfOrigContents = inContents
             }
       , catOutput =
@@ -200,7 +193,8 @@ test-suite testss
   main-is: Main.hs
   type: exitcode-stdio-1.0
   other-modules:
-    Test.Mod1, Mod3,
+    Test.Mod1,
+    Mod3,
     Dir.Mod1,
     Dir.Mod2
 |]
@@ -225,6 +219,268 @@ test-suite testss
     Dir.Mod2
 |]
 
+caseMultipleOtherModulesUsingSpaces :: TestTree
+caseMultipleOtherModulesUsingSpaces =
+  mkTest $
+    CabalAddTest
+      { catName = "add multiple other modules with space separators"
+      , catConfig =
+          Config
+            { cnfComponent = Right $ CTestName "testss"
+            , cnfAdditions = NE.fromList ["Test.Mod1", "Mod3"]
+            , cnfTargetField = OtherModules
+            , cnfFields = parseCabalFileOrError inContents
+            , cnfOrigContents = inContents
+            }
+      , catOutput =
+          [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+test-suite testss
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
+  other-modules:
+    Test.Mod1
+    Mod3
+    Dir.Mod1
+    Dir.Mod2
+
+library
+  build-depends:
+    base >=4.15 && <5
+  exposed-modules: Test.Mod1, Test.Mod2
+|]
+      }
+  where
+    inContents =
+      [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+test-suite testss
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
+  other-modules:
+    Dir.Mod1
+    Dir.Mod2
+
+library
+  build-depends:
+    base >=4.15 && <5
+  exposed-modules: Test.Mod1, Test.Mod2
+|]
+
+caseMultipleOtherModulesUsingLeadingCommas :: TestTree
+caseMultipleOtherModulesUsingLeadingCommas =
+  mkTest $
+    CabalAddTest
+      { catName = "add multiple other modules preserving leading commas"
+      , catConfig =
+          Config
+            { cnfComponent = Right $ CTestName "testss"
+            , cnfAdditions = NE.fromList ["Test.Mod1", "Mod3"]
+            , cnfTargetField = OtherModules
+            , cnfFields = parseCabalFileOrError inContents
+            , cnfOrigContents = inContents
+            }
+      , catOutput =
+          [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+test-suite testss
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
+  other-modules:  Test.Mod1
+                , Mod3
+                , Dir.Mod1
+                , Dir.Mod2
+
+library
+  build-depends:
+    base >=4.15 && <5
+  exposed-modules: Test.Mod1, Test.Mod2
+|]
+      }
+  where
+    inContents =
+      [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+test-suite testss
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
+  other-modules:  Dir.Mod1
+                , Dir.Mod2
+
+library
+  build-depends:
+    base >=4.15 && <5
+  exposed-modules: Test.Mod1, Test.Mod2
+|]
+
+caseMultipleOtherModulesUsingLeadingSpaces :: TestTree
+caseMultipleOtherModulesUsingLeadingSpaces =
+  mkTest $
+    CabalAddTest
+      { catName = "add multiple other modules preserving leading spaces"
+      , catConfig =
+          Config
+            { cnfComponent = Right $ CTestName "testss"
+            , cnfAdditions = NE.fromList ["Test.Mod1", "Mod3"]
+            , cnfTargetField = OtherModules
+            , cnfFields = parseCabalFileOrError inContents
+            , cnfOrigContents = inContents
+            }
+      , catOutput =
+          [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+test-suite testss
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
+  other-modules:  Test.Mod1
+                  Mod3
+                  Dir.Mod1
+                  Dir.Mod2
+
+library
+  build-depends:
+    base >=4.15 && <5
+  exposed-modules: Test.Mod1, Test.Mod2
+|]
+      }
+  where
+    inContents =
+      [s|
+name:          dummy
+version:       0.13.0.0
+cabal-version: 2.0
+build-type:    Simple
+
+test-suite testss
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
+  other-modules:  Dir.Mod1
+                  Dir.Mod2
+
+library
+  build-depends:
+    base >=4.15 && <5
+  exposed-modules: Test.Mod1, Test.Mod2
+|]
+
+caseMultipleOtherModulesWithImportFields :: TestTree
+caseMultipleOtherModulesWithImportFields =
+  mkTest $
+    CabalAddTest
+      { catName = "add multiple other modules with import field"
+      , catConfig =
+          Config
+            { cnfComponent = Right $ CLibName LMainLibName
+            , cnfAdditions = NE.fromList ["This.Dir.Mod1", "Mod3"]
+            , cnfTargetField = OtherModules
+            , cnfFields = parseCabalFileOrError inContents
+            , cnfOrigContents = inContents
+            }
+      , catOutput =
+          [s|
+cabal-version: 2.2
+name:          dummy
+version:       0.13.0.0
+build-type:    Simple
+
+common foo
+  build-depends: bar
+  other-modules: Other
+
+library
+  import: foo
+  other-modules: This.Dir.Mod1, Mod3
+  build-depends: foo < 1 && >0.7, quux < 1
+  exposed-modules: Foo
+|]
+      }
+  where
+    inContents =
+      [s|
+cabal-version: 2.2
+name:          dummy
+version:       0.13.0.0
+build-type:    Simple
+
+common foo
+  build-depends: bar
+  other-modules: Other
+
+library
+  import: foo
+  build-depends: foo < 1 && >0.7, quux < 1
+  exposed-modules: Foo
+|]
+
+caseMultipleOtherModulesWithImportFields2 :: TestTree
+caseMultipleOtherModulesWithImportFields2 =
+  mkTest $
+    CabalAddTest
+      { catName = "add multiple other modules with capitalised import field"
+      , catConfig =
+          Config
+            { cnfComponent = Right $ CLibName LMainLibName
+            , cnfAdditions = NE.fromList ["This.Dir.Mod1", "Mod3"]
+            , cnfTargetField = OtherModules
+            , cnfFields = parseCabalFileOrError inContents
+            , cnfOrigContents = inContents
+            }
+      , catOutput =
+          [s|
+cabal-version: 2.2
+name:          dummy
+version:       0.13.0.0
+build-type:    Simple
+
+common foo
+  build-depends: bar
+  other-modules: Other
+
+library
+  Import: foo
+  other-modules: This.Dir.Mod1, Mod3
+  build-depends: foo < 1 && >0.7, quux < 1
+  exposed-modules: Foo
+|]
+      }
+  where
+    inContents =
+      [s|
+cabal-version: 2.2
+name:          dummy
+version:       0.13.0.0
+build-type:    Simple
+
+common foo
+  build-depends: bar
+  other-modules: Other
+
+library
+  Import: foo
+  build-depends: foo < 1 && >0.7, quux < 1
+  exposed-modules: Foo
+|]
+
 prettyDiff :: [Diff String] -> String
 prettyDiff =
   unlines
@@ -247,4 +503,9 @@ main =
       , caseMultipleExposedModules1
       , caseMultipleExposedModulesUsingSpaces
       , caseMultipleOtherModules
+      , caseMultipleOtherModulesUsingSpaces
+      , caseMultipleOtherModulesUsingLeadingCommas
+      , caseMultipleOtherModulesUsingLeadingSpaces
+      , caseMultipleOtherModulesWithImportFields
+      , caseMultipleOtherModulesWithImportFields2
       ]


### PR DESCRIPTION
Added a target field to the config, which defines the field of the component to add the given values to.
The algorithms now adds values to the target field instead of always adding to `build-depends`.

The `executeConfig` function can now be configured to add to different fields while the cli tool will still always use execute config for `build-depends`.
This would be very useful for HLS, as we want to use `cabal-add` as a library to be able to offer code actions to add unknown modules to cabal files in a project.

Added some tests, verifying that modules can be added correctly with the right config.
If the previously written modules are separated by a space, instead of a comma, we currently don't extend accordingly, this is  reflected in a test which currently fails.
